### PR TITLE
Add dummy IViewScroller implementation

### DIFF
--- a/Microsoft.VisualStudio.MiniEditor/BaseViewImpl/TestTextView.cs
+++ b/Microsoft.VisualStudio.MiniEditor/BaseViewImpl/TestTextView.cs
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.Text.Editor.Implementation
 
         public IBufferGraph BufferGraph => _factoryService.BufferGraphFactoryService.CreateBufferGraph (_textBuffer);
 
-		public IViewScroller ViewScroller => throw new NotImplementedException ();
+		public IViewScroller ViewScroller => TestViewScroller.Instance;
 
 		public double ViewportBottom => ViewportTop + ViewportHeight;
 

--- a/Microsoft.VisualStudio.MiniEditor/BaseViewImpl/TestViewScroller.cs
+++ b/Microsoft.VisualStudio.MiniEditor/BaseViewImpl/TestViewScroller.cs
@@ -1,0 +1,37 @@
+﻿namespace Microsoft.VisualStudio.Text.Editor.Implementation
+{
+	internal class TestViewScroller : IViewScroller
+	{
+		public static readonly TestViewScroller Instance = new TestViewScroller();
+
+		public void EnsureSpanVisible(SnapshotSpan span)
+		{
+		}
+
+		public void EnsureSpanVisible(SnapshotSpan span, EnsureSpanVisibleOptions options)
+		{
+		}
+
+		public void EnsureSpanVisible(VirtualSnapshotSpan span, EnsureSpanVisibleOptions options)
+		{
+		}
+
+		public void ScrollViewportHorizontallyByPixels(double distanceToScroll)
+		{
+		}
+
+		public void ScrollViewportVerticallyByLine(ScrollDirection direction)
+		{
+		}
+
+		public void ScrollViewportVerticallyByLines(ScrollDirection direction, int count)
+		{
+		}
+
+		public bool ScrollViewportVerticallyByPage(ScrollDirection direction) => true;
+
+		public void ScrollViewportVerticallyByPixels(double distanceToScroll)
+		{
+		}
+	}
+}


### PR DESCRIPTION
While the interface doesn't make sense for MiniEditor it's still being used as a dependency in things like IEditorOperations thus implement a no-op version for those to work.